### PR TITLE
fix duplicate rating constant

### DIFF
--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -327,4 +327,5 @@ export const getUserByEmail = async (email: string): Promise<User | null> => {
   return user || null;
 };
 
-export const FLOOR_RATING = 800;
+// Re-export the floor rating constant from the rating calculation module
+export { FLOOR_RATING } from "@/lib/ratingCalculation";


### PR DESCRIPTION
## Summary
- remove duplicated constant from mock data
- reference `FLOOR_RATING` from `ratingCalculation.ts`

## Testing
- `npx --yes jest` *(fails: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6841c7bf117c8322a1ca2f3b83b213c0