### PR TITLE
Fix jest transform for ESM

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -9,9 +9,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
   testMatch: ['**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
   transform: {
-    '^.+\\.tsx?$': ['ts-jest', {
-      tsconfig: 'tsconfig.json',
-    }],
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.app.json', useESM: true }],
   },
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',


### PR DESCRIPTION
## Summary
- update jest config to compile TS files in ESM mode

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npx -y jest@29.7.0` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d91473508322b2cccbb263c8cc48