### PR TITLE
Add Jest wrappers around system test runners

### DIFF
--- a/src/tests/system/playerApprovalFlow.test.ts
+++ b/src/tests/system/playerApprovalFlow.test.ts
@@ -106,4 +106,10 @@ const runPlayerApprovalFlowTest = async (): Promise<boolean> => {
   }
 };
 
+
 export { runPlayerApprovalFlowTest };
+
+test('player approval flow', async () => {
+  const result = await runPlayerApprovalFlowTest();
+  expect(result).toBe(true);
+});

--- a/src/tests/system/ratingCalculationFlow.test.ts
+++ b/src/tests/system/ratingCalculationFlow.test.ts
@@ -204,4 +204,10 @@ const runRatingCalculationFlowTest = async (): Promise<boolean> => {
   }
 };
 
+
 export { runRatingCalculationFlowTest };
+
+test('rating calculation flow', async () => {
+  const result = await runRatingCalculationFlowTest();
+  expect(result).toBe(true);
+});

--- a/src/tests/system/registrationFlow.test.ts
+++ b/src/tests/system/registrationFlow.test.ts
@@ -89,4 +89,10 @@ const runRegistrationFlowTest = async (): Promise<boolean> => {
   }
 };
 
+
 export { runRegistrationFlowTest };
+
+test('registration flow', async () => {
+  const result = await runRegistrationFlowTest();
+  expect(result).toBe(true);
+});

--- a/src/tests/system/tournamentFlow.test.ts
+++ b/src/tests/system/tournamentFlow.test.ts
@@ -164,4 +164,10 @@ const runTournamentFlowTest = async (): Promise<boolean> => {
   }
 };
 
+
 export { runTournamentFlowTest };
+
+test('tournament flow', async () => {
+  const result = await runTournamentFlowTest();
+  expect(result).toBe(true);
+});


### PR DESCRIPTION
## Summary
- enable Jest execution for system tests
- add `test()` blocks that call flow runner functions

## Testing
- `npm test` *(fails: 7 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6841f2fb7298832288eaf5450f4ca469