### PR TITLE
Wrap system test runners in Jest tests

### DIFF
--- a/src/tests/system/playerApprovalFlow.test.ts
+++ b/src/tests/system/playerApprovalFlow.test.ts
@@ -107,3 +107,8 @@ const runPlayerApprovalFlowTest = async (): Promise<boolean> => {
 };
 
 export { runPlayerApprovalFlowTest };
+
+test('player approval flow', async () => {
+  const result = await runPlayerApprovalFlowTest();
+  expect(result).toBe(true);
+});

--- a/src/tests/system/ratingCalculationFlow.test.ts
+++ b/src/tests/system/ratingCalculationFlow.test.ts
@@ -205,3 +205,8 @@ const runRatingCalculationFlowTest = async (): Promise<boolean> => {
 };
 
 export { runRatingCalculationFlowTest };
+
+test('rating calculation flow', async () => {
+  const result = await runRatingCalculationFlowTest();
+  expect(result).toBe(true);
+});

--- a/src/tests/system/registrationFlow.test.ts
+++ b/src/tests/system/registrationFlow.test.ts
@@ -90,3 +90,8 @@ const runRegistrationFlowTest = async (): Promise<boolean> => {
 };
 
 export { runRegistrationFlowTest };
+
+test('registration flow', async () => {
+  const result = await runRegistrationFlowTest();
+  expect(result).toBe(true);
+});

--- a/src/tests/system/tournamentFlow.test.ts
+++ b/src/tests/system/tournamentFlow.test.ts
@@ -165,3 +165,8 @@ const runTournamentFlowTest = async (): Promise<boolean> => {
 };
 
 export { runTournamentFlowTest };
+
+test('tournament flow', async () => {
+  const result = await runTournamentFlowTest();
+  expect(result).toBe(true);
+});


### PR DESCRIPTION
## Summary
- execute system test runners inside Jest `test` blocks so Jest recognizes them
- run `npm test` to verify the new tests are discovered

## Testing
- `npm test` *(fails: 7 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6841f3d4a5108322a86bc55771c06147