### PR TITLE
Fix system test setup storage

### DIFF
--- a/src/tests/system/setup.ts
+++ b/src/tests/system/setup.ts
@@ -1,5 +1,5 @@
 import { supabase } from "@/integrations/supabase/client";
-import { saveToStorage, clearAllData } from "@/utils/storageUtils";
+import { clearAllData } from "@/utils/storageUtils";
 import { STORAGE_KEYS } from "@/contexts/user/userContextTypes";
 import { logMessage, LogLevel } from "@/utils/debugLogger";
 
@@ -92,8 +92,8 @@ export const setupSystemTest = async (): Promise<void> => {
     await clearAllData();
     
     // Initialize empty data structures
-    saveToStorage(STORAGE_KEYS.USERS, []);
-    saveToStorage(STORAGE_KEYS.CURRENT_USER, null);
+    localStorage.setItem(STORAGE_KEYS.USERS, JSON.stringify([]));
+    localStorage.setItem(STORAGE_KEYS.CURRENT_USER, JSON.stringify(null));
     
     // Sign out of Supabase if signed in
     await supabase.auth.signOut();


### PR DESCRIPTION
## Summary
- use direct `localStorage.setItem` calls instead of `saveToStorage` in system test setup
- drop the unused import

## Testing
- `npm test` *(fails: 4 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6841f55917208322aec9a4a38a723761