### PR TITLE
Fix dashboard navigation

### DIFF
--- a/src/components/organizer/dashboard/DashboardHeader.tsx
+++ b/src/components/organizer/dashboard/DashboardHeader.tsx
@@ -12,7 +12,7 @@ export function DashboardHeader({ organizerName }: DashboardHeaderProps) {
   return (
     <div className="flex justify-between items-center mb-8">
       <h1 className="text-2xl font-bold">Welcome, {organizerName}</h1>
-      <Button onClick={() => navigate('/tournaments/new')}>
+      <Button onClick={() => navigate('/tournament-management/new')}>
         Create Tournament
       </Button>
     </div>

--- a/src/components/organizer/dashboard/__tests__/DashboardHeader.test.tsx
+++ b/src/components/organizer/dashboard/__tests__/DashboardHeader.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import { DashboardHeader } from '../DashboardHeader';
+
+test('navigates to CreateTournament page when clicking Create Tournament', async () => {
+  render(
+    <MemoryRouter initialEntries={["/"]}>
+      <Routes>
+        <Route path="/" element={<DashboardHeader organizerName="Test" />} />
+        <Route path="/tournament-management/new" element={<div>Create Tournament Page</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  const button = screen.getByRole('button', { name: /create tournament/i });
+  await userEvent.click(button);
+
+  expect(screen.getByText('Create Tournament Page')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- change the create tournament link
- test DashboardHeader navigation

## Testing
- `npm test -- --runInBand` *(fails: StorageUtils, LoginFormInputs, loginOperations)*
- `npx jest src/components/organizer/dashboard/__tests__/DashboardHeader.test.tsx --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6842110139208322b87913a39aea78fb