### PR TITLE
Fix tournament detail path

### DIFF
--- a/src/components/officer/ApprovedTournaments.tsx
+++ b/src/components/officer/ApprovedTournaments.tsx
@@ -27,7 +27,7 @@ const ApprovedTournaments: React.FC<ApprovedTournamentsProps> = ({
   const [isViewAllVisible, setIsViewAllVisible] = useState(true);
   
   const handleNavigateToTournament = (tournamentId: string) => {
-    navigate(`/tournament/${tournamentId}`);
+    navigate(`/tournaments/${tournamentId}`);
   };
   
   const viewAllTournaments = () => {

--- a/src/components/player/PlayerPerformance.tsx
+++ b/src/components/player/PlayerPerformance.tsx
@@ -125,7 +125,7 @@ const PlayerPerformance: React.FC<PlayerPerformanceProps> = ({ player }) => {
                       <TableRow 
                         key={result.tournamentId} 
                         className="cursor-pointer hover:bg-muted"
-                        onClick={() => navigate(`/tournament/${result.tournamentId}`)}
+                        onClick={() => navigate(`/tournaments/${result.tournamentId}`)}
                       >
                         <TableCell className="font-medium">
                           <div className="flex items-center gap-2">

--- a/src/hooks/useCreateTournamentForm.ts
+++ b/src/hooks/useCreateTournamentForm.ts
@@ -126,7 +126,7 @@ export function useCreateTournamentForm() {
         description: 'Tournament created successfully',
       });
 
-      navigate(`/tournament/${tournament.id}`);
+      navigate(`/tournaments/${tournament.id}`);
     } catch (error: any) {
       console.error('Error creating tournament:', error);
       toast({

--- a/src/pages/Tournaments.tsx
+++ b/src/pages/Tournaments.tsx
@@ -145,7 +145,7 @@ const Tournaments = () => {
             <TournamentCard
               key={tournament.id}
               tournament={tournament}
-              onClickView={() => navigate(`/tournament/${tournament.id}`)}
+              onClickView={() => navigate(`/tournaments/${tournament.id}`)}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- link to tournament details should be `/tournaments/${id}`
- update various components to use the correct path

## Testing
- `npm test` *(fails: Test Suites: 4 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684210febde88322bbeee7be49cb3b32