### PR TITLE
Fix login input structure

### DIFF
--- a/src/components/login/LoginFormInputs.tsx
+++ b/src/components/login/LoginFormInputs.tsx
@@ -63,10 +63,10 @@ const LoginFormInputs = ({
         render={({ field }) => (
           <FormItem>
             <FormLabel>Email</FormLabel>
-            <FormControl>
-              <div className="relative">
-                <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                <Input 
+            <div className="relative">
+              <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+              <FormControl>
+                <Input
                   placeholder={emailPlaceholder}
                   className={`pl-10 ${emailReadOnly ? 'bg-gray-100' : ''}`}
                   type="email"
@@ -75,8 +75,8 @@ const LoginFormInputs = ({
                   onChange={field.onChange}
                   onBlur={field.onBlur}
                 />
-              </div>
-            </FormControl>
+              </FormControl>
+            </div>
             {selectedRole === "rating_officer" && (
               <FormDescription>
                 Fixed email for Rating Officer login
@@ -93,30 +93,31 @@ const LoginFormInputs = ({
         render={({ field }) => (
           <FormItem>
             <FormLabel>{passwordLabel}</FormLabel>
-            <FormControl>
-              <div className="relative">
-                <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                <Input 
+            <div className="relative">
+              <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+              <FormControl>
+                <Input
                   placeholder={passwordPlaceholder}
-                  className="pl-10 pr-10" 
+                  className="pl-10 pr-10"
                   type={showPassword ? "text" : "password"}
                   {...field}
                 />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="absolute right-0 top-0 h-10 px-3 text-gray-400 hover:text-gray-500"
-                  onClick={togglePasswordVisibility}
-                >
-                  {showPassword ? (
-                    <EyeOff className="h-4 w-4" />
-                  ) : (
-                    <Eye className="h-4 w-4" />
-                  )}
-                </Button>
-              </div>
-            </FormControl>
+              </FormControl>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="absolute right-0 top-0 h-10 px-3 text-gray-400 hover:text-gray-500"
+                onClick={togglePasswordVisibility}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+              >
+                {showPassword ? (
+                  <EyeOff className="h-4 w-4" />
+                ) : (
+                  <Eye className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
             {selectedRole === "rating_officer" && (
               <FormDescription>
                 Use RNCR25 as the access code

--- a/src/components/login/__tests__/LoginFormInputs.test.tsx
+++ b/src/components/login/__tests__/LoginFormInputs.test.tsx
@@ -50,7 +50,9 @@ describe('LoginFormInputs', () => {
     it('renders password field for tournament organizer role', () => {
       render(<LoginFormWrapper selectedRole="tournament_organizer" />);
       
-      const passwordInput = screen.getByLabelText(/Password/i);
+      const passwordInput = screen.getByLabelText(/Password/i, {
+        selector: 'input'
+      });
       expect(passwordInput).toBeInTheDocument();
       expect(passwordInput).toHaveAttribute('type', 'password');
     });
@@ -84,7 +86,9 @@ describe('LoginFormInputs', () => {
       />
     );
     
-    const visibilityButton = screen.getByRole('button', { name: '' });
+    const visibilityButton = screen.getByRole('button', {
+      name: /show password/i
+    });
     visibilityButton.click();
     
     expect(togglePasswordVisibility).toHaveBeenCalledTimes(1);
@@ -93,8 +97,12 @@ describe('LoginFormInputs', () => {
   it('shows password in plain text for both roles when showPassword is true', () => {
     render(<LoginFormWrapper selectedRole="tournament_organizer" showPassword={true} />);
     render(<LoginFormWrapper selectedRole="rating_officer" showPassword={true} />);
-    
-    const passwordInput = screen.getByLabelText(/Password|Access Code/i);
-    expect(passwordInput).toHaveAttribute('type', 'text');
+
+    const passwordInputs = screen.getAllByLabelText(/Password|Access Code/i, {
+      selector: 'input'
+    });
+    passwordInputs.forEach((input) => {
+      expect(input).toHaveAttribute('type', 'text');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- keep icon wrapper div but wrap Input directly with FormControl
- give password toggle button an aria-label
- update tests to use new accessible name

## Testing
- `npx jest src/components/login/__tests__/LoginFormInputs.test.tsx`
- `npm test` *(fails: Storage Utils, login operations, and system tests)*

------
https://chatgpt.com/codex/tasks/task_e_6841f0f6006483228e18a19ebb1080e1